### PR TITLE
Optimize `abs`

### DIFF
--- a/src/math/Math.sol
+++ b/src/math/Math.sol
@@ -6,12 +6,15 @@ pragma solidity ^0.8.0;
 /// @custom:contact security@morpho.xyz
 /// @dev Library to perform simple math manipulations.
 library Math {
-    function abs(int256 x) internal pure returns (int256 y) {
-        if (x == type(int256).min) return type(int256).max;
+    /* CONSTANTS */
 
+    // Only direct number constants and references to such constants are supported by inline assembly.
+    int256 internal constant MIN_INT256 = -2 ** 255;
+
+    function abs(int256 x) internal pure returns (int256 y) {
         assembly {
             let mask := sar(255, x)
-            y := xor(add(x, mask), mask)
+            y := xor(add(x, mask), mul(mask, iszero(eq(x, MIN_INT256))))
         }
     }
 


### PR DESCRIPTION
It gains an additional 26 gas compared to the target branch on the `abs` function