### PR TITLE
Factorize math constants

### DIFF
--- a/src/math/CompoundMath.sol
+++ b/src/math/CompoundMath.sol
@@ -1,19 +1,13 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.0;
 
+import "./MathConstants.sol";
+
 /// @title Compound Math Library.
 /// @author Morpho Labs.
 /// @custom:contact security@morpho.xyz
 /// @dev Library to perform Compound's multiplication and division in an efficient way.
 library CompoundMath {
-    /* CONSTANTS */
-    // Only direct number constants and references to such constants are supported by inline assembly.
-
-    uint256 internal constant WAD = 1e18;
-    uint256 internal constant MAX_UINT256 = 2 ** 256 - 1;
-
-    /* INTERNAL */
-
     function mul(uint256 x, uint256 y) internal pure returns (uint256 z) {
         assembly {
             // Revert if x * y > type(uint256).max

--- a/src/math/Math.sol
+++ b/src/math/Math.sol
@@ -1,18 +1,13 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.0;
 
+import "./MathConstants.sol";
+
 /// @title Math Library.
 /// @author Morpho Labs.
 /// @custom:contact security@morpho.xyz
 /// @dev Library to perform simple math manipulations.
 library Math {
-    /* CONSTANTS */
-    // Only direct number constants and references to such constants are supported by inline assembly.
-
-    int256 internal constant MIN_INT256 = -2 ** 255;
-
-    /* INTERNAL */
-
     function abs(int256 x) internal pure returns (int256 y) {
         assembly {
             let mask := sar(255, x)

--- a/src/math/MathConstants.sol
+++ b/src/math/MathConstants.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.0;
+
+// Only direct number constants and references to such constants are supported by inline assembly.
+
+int256 constant MIN_INT256 = -2 ** 255;
+uint256 constant MAX_UINT256 = 2 ** 256 - 1;
+
+uint256 constant PERCENTAGE_FACTOR = 100_00;
+uint256 constant HALF_PERCENTAGE_FACTOR = 50_00;
+uint256 constant PERCENTAGE_FACTOR_MINUS_ONE = 100_00 - 1;
+uint256 constant MAX_UINT256_MINUS_HALF_PERCENTAGE_FACTOR = 2 ** 256 - 1 - 50_00;
+uint256 constant MAX_UINT256_MINUS_PERCENTAGE_FACTOR_MINUS_ONE = 2 ** 256 - 1 - (100_00 - 1);
+
+uint256 constant WAD = 1e18;
+uint256 constant HALF_WAD = 0.5e18;
+uint256 constant WAD_MINUS_ONE = 1e18 - 1;
+uint256 constant RAY = 1e27;
+uint256 constant HALF_RAY = 0.5e27;
+uint256 constant RAY_MINUS_ONE = 1e27 - 1;
+uint256 constant RAY_WAD_RATIO = 1e9;
+uint256 constant HALF_RAY_WAD_RATIO = 0.5e9;
+uint256 constant MAX_UINT256_MINUS_HALF_WAD = 2 ** 256 - 1 - 0.5e18;
+uint256 constant MAX_UINT256_MINUS_HALF_RAY = 2 ** 256 - 1 - 0.5e27;
+uint256 constant MAX_UINT256_MINUS_WAD_MINUS_ONE = 2 ** 256 - 1 - (1e18 - 1);
+uint256 constant MAX_UINT256_MINUS_RAY_MINUS_ONE = 2 ** 256 - 1 - (1e27 - 1);

--- a/src/math/PercentageMath.sol
+++ b/src/math/PercentageMath.sol
@@ -1,23 +1,13 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.0;
 
+import "./MathConstants.sol";
+
 /// @title PercentageMath.
 /// @author Morpho Labs.
 /// @custom:contact security@morpho.xyz
 /// @notice Optimized version of Aave V3 math library PercentageMath to conduct percentage manipulations: https://github.com/aave/aave-v3-core/blob/master/contracts/protocol/libraries/math/PercentageMath.sol
 library PercentageMath {
-    /* CONSTANTS */
-    // Only direct number constants and references to such constants are supported by inline assembly.
-
-    uint256 internal constant PERCENTAGE_FACTOR = 100_00;
-    uint256 internal constant HALF_PERCENTAGE_FACTOR = 50_00;
-    uint256 internal constant PERCENTAGE_FACTOR_MINUS_ONE = 100_00 - 1;
-    uint256 internal constant MAX_UINT256 = 2 ** 256 - 1;
-    uint256 internal constant MAX_UINT256_MINUS_HALF_PERCENTAGE_FACTOR = 2 ** 256 - 1 - 50_00;
-    uint256 internal constant MAX_UINT256_MINUS_PERCENTAGE_FACTOR_MINUS_ONE = 2 ** 256 - 1 - (100_00 - 1);
-
-    /* INTERNAL */
-
     /// @notice Executes the bps-based percentage addition (x * (1 + p)), rounded half up.
     /// @param x The value to which to add the percentage.
     /// @param percentage The percentage of the value to add (in bps).

--- a/src/math/WadRayMath.sol
+++ b/src/math/WadRayMath.sol
@@ -1,30 +1,13 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.0;
 
+import "./MathConstants.sol";
+
 /// @title WadRayMath.
 /// @author Morpho Labs.
 /// @custom:contact security@morpho.xyz
 /// @notice Optimized version of Aave V3 math library WadRayMath to conduct wad and ray manipulations: https://github.com/aave/aave-v3-core/blob/master/contracts/protocol/libraries/math/WadRayMath.sol
 library WadRayMath {
-    /* CONSTANTS */
-    // Only direct number constants and references to such constants are supported by inline assembly.
-
-    uint256 internal constant WAD = 1e18;
-    uint256 internal constant HALF_WAD = 0.5e18;
-    uint256 internal constant WAD_MINUS_ONE = 1e18 - 1;
-    uint256 internal constant RAY = 1e27;
-    uint256 internal constant HALF_RAY = 0.5e27;
-    uint256 internal constant RAY_MINUS_ONE = 1e27 - 1;
-    uint256 internal constant RAY_WAD_RATIO = 1e9;
-    uint256 internal constant HALF_RAY_WAD_RATIO = 0.5e9;
-    uint256 internal constant MAX_UINT256 = 2 ** 256 - 1;
-    uint256 internal constant MAX_UINT256_MINUS_HALF_WAD = 2 ** 256 - 1 - 0.5e18;
-    uint256 internal constant MAX_UINT256_MINUS_HALF_RAY = 2 ** 256 - 1 - 0.5e27;
-    uint256 internal constant MAX_UINT256_MINUS_WAD_MINUS_ONE = 2 ** 256 - 1 - (1e18 - 1);
-    uint256 internal constant MAX_UINT256_MINUS_RAY_MINUS_ONE = 2 ** 256 - 1 - (1e27 - 1);
-
-    /* INTERNAL */
-
     /// @dev Executes the wad-based multiplication of 2 numbers, rounded half up.
     /// @param x Wad.
     /// @param y Wad.


### PR DESCRIPTION
The purpose of this PR is to avoid defining the same constants multiple times, so they are all defined at the same place and used when needed