### PR TITLE
[Tests] Fix bounds in the revert conditions

### DIFF
--- a/test/TestPercentageMath.sol
+++ b/test/TestPercentageMath.sol
@@ -121,6 +121,11 @@ contract TestPercentageMath is Test {
         mock.percentMulUp(x, y);
     }
 
+    function testPercentMulUpOverflowBound() public {
+        vm.expectRevert();
+        mock.percentMulUp(MAX_UINT256_PERCENT_UP + 1, 1);
+    }
+
     function testPercentDiv(uint256 x, uint256 p) public {
         vm.assume(p > 0 && x <= (type(uint256).max - p / 2) / PERCENTAGE_FACTOR);
 

--- a/test/TestPercentageMath.sol
+++ b/test/TestPercentageMath.sol
@@ -9,7 +9,7 @@ contract TestPercentageMath is Test {
     uint256 internal constant PERCENTAGE_FACTOR = 100_00;
     uint256 internal constant HALF_PERCENTAGE_FACTOR = 50_00;
 
-    uint256 internal constant MAX_UINT256_PERCENT_UP = type(uint256).max - PERCENTAGE_FACTOR - 1;
+    uint256 internal constant MAX_UINT256_PERCENT_UP = type(uint256).max - (PERCENTAGE_FACTOR - 1);
     uint256 internal constant MAX_UINT256_PERCENT_HALF_UP = type(uint256).max - HALF_PERCENTAGE_FACTOR;
 
     PercentageMathMock mock;

--- a/test/TestWadRayMath.sol
+++ b/test/TestWadRayMath.sol
@@ -13,10 +13,10 @@ contract TestWadRayMath is Test {
     uint256 internal constant RAY_WAD_RATIO = RAY / WAD;
     uint256 internal constant HALF_RAY_WAD_RATIO = RAY_WAD_RATIO / 2;
 
-    uint256 internal constant MAX_UINT256_WAD_UP = type(uint256).max - WAD - 1;
+    uint256 internal constant MAX_UINT256_WAD_UP = type(uint256).max - (WAD - 1);
     uint256 internal constant MAX_UINT256_WAD_HALF_UP = type(uint256).max - HALF_WAD;
 
-    uint256 internal constant MAX_UINT256_RAY_UP = type(uint256).max - RAY - 1;
+    uint256 internal constant MAX_UINT256_RAY_UP = type(uint256).max - (RAY - 1);
     uint256 internal constant MAX_UINT256_RAY_HALF_UP = type(uint256).max - HALF_RAY;
 
     WadRayMathMock mock;

--- a/test/TestWadRayMath.sol
+++ b/test/TestWadRayMath.sol
@@ -76,6 +76,11 @@ contract TestWadRayMath is Test {
         mock.wadMulUp(x, y);
     }
 
+    function testWadMulUpOverflowBound() public {
+        vm.expectRevert();
+        mock.wadMulUp(MAX_UINT256_WAD_UP + 1, 1);
+    }
+
     function testWadDivRef(uint256 x, uint256 y) public {
         vm.assume(y > 0 && x <= (type(uint256).max - y / 2) / WAD);
 
@@ -183,6 +188,11 @@ contract TestWadRayMath is Test {
 
         vm.expectRevert();
         mock.rayMulUp(x, y);
+    }
+
+    function testRayMulUpOverflowBound() public {
+        vm.expectRevert();
+        mock.rayMulUp(MAX_UINT256_RAY_UP + 1, 1);
     }
 
     function testRayDivRef(uint256 x, uint256 y) public {


### PR DESCRIPTION
The bounds are subtracting one instead of adding one, see failing tests in the first commit